### PR TITLE
Minor corrections and clarifications to the documentation

### DIFF
--- a/docs/Environment-settings.md
+++ b/docs/Environment-settings.md
@@ -2,6 +2,8 @@
 
 This file is encoded in a binary serialized format.  Each value begins with a type byte.  Following the type byte is the variable data.
 
+The saves.dat file that stores the game's configuration and save slots also uses this format.
+
 The following types are known:
 * `T` (0x54): Dictionary - pairs of null-terminated string keys and typed values.  Closed when a zero-length key is encountered.
 * `I` (0x49): Integer array - 32-bit integer count followed by count 32-bit integer values.
@@ -11,5 +13,5 @@ The following types are known:
 * `S` (0x53): String array - 32-bit integer count followed by count null-terminated strings.
 * `s` (0x73): String - null-terminated string.
 * `M` (0x4D): Typed array - 32-bit integer count followed by count typed values.
-* `R` (0x52): _Reference(?)_ array - 32-bit integer count followed by count _null-terminated reference strings(?)_
+* `R` (0x52): Raw binary data - 32-bit integer count followed by count bytes.
 * `.` (0x2E): Null

--- a/docs/INOD-(Instance-Node).md
+++ b/docs/INOD-(Instance-Node).md
@@ -5,8 +5,8 @@ These objects appear to contain position and rotation data. Each contains one 4 
 Offset   | Size     | Type         | Meaning
 ---------|----------|--------------|----------
 0x0000   | 4        | `int`        | Appears to be a unique id.
-0x0004   | 4        | `int`        | Appears to be an index into the model set list in `inst_header`.
-0x0008   | 12       | `float`      | Appears to be position data.
+0x0004   | 4        | `int`        | Index into the model set list in `inst_header`.
+0x0008   | 12       | `float`      | Position X, Y & Z coordinates. X and Y coordinates are on a scale of 0.0 to 8192.0 and are rotated 90 degrees counter-clockwise compared to the in-game map, so 0x0 is the bottom-left corner, 8192x0 is the top-left corner and 8192x8192 is the top-right corner.
 0x0014   | 4        | ???          | Unknown.
 0x0018   | 4        | `float`      | Appears to be a rotation around the Z axis in radians.
 0x001c   | 4        | ???          | Unknown.

--- a/docs/IonFx-Miasmata-RS5-file-format.md
+++ b/docs/IonFx-Miasmata-RS5-file-format.md
@@ -39,7 +39,7 @@ Offset   | Size     | Type         | Meaning
 0x000C   | 4        | ???          | Unknown - seems to always be `0x80000000` for present entries
 0x0010   | 4        | ???          | Unknown - seems to always be `0x00000300` for present entries
 0x0014   | 4        | `byte[]`     | FourCC - identifies type of object
-0x0018   | 8        | ???          | Unknown - appears to be about twice the size of the uncompressed data
+0x0018   | 8        | long         | The size of the uncompressed data shifted left by one bit. The low bit is always 1 for a valid entry and 0 otherwise.
 0x0020   | 8        | `FILETIME`   | Appears to be the modification time of the object
 0x0028   | 128      | `ASCIZ`      | Null-terminated name of object
 


### PR DESCRIPTION
Hey klightspeed,

Your documentation looks good to me - I just went through and added a few notes from my own reverse engineering efforts.

FYI - the R type isn't really used much in the environment file, but it is used in the saves.dat for the exposure_map and a few other things.
