### PR TITLE
Multiple issue fixes

### DIFF
--- a/LibRS5/RS5Archive.cs
+++ b/LibRS5/RS5Archive.cs
@@ -133,8 +133,11 @@ namespace LibRS5
                     for (int i = 1; i < nrents; i++)
                     {
                         RS5DirectoryEntry dirent = GetDirectoryEntry(directoryData, i * DirectoryEntryLength);
-                        CentralDirectoryEntries[i] = dirent;
-                        CentralDirectoryLookup[dirent.Name] = i;
+                        if (dirent.DataLength > 0)
+                        {
+                            CentralDirectoryEntries[i] = dirent;
+                            CentralDirectoryLookup[dirent.Name] = i;
+                        }
                     }
                 }
                 else

--- a/LibRS5/RS5ArchiveCollection.cs
+++ b/LibRS5/RS5ArchiveCollection.cs
@@ -15,10 +15,7 @@ namespace LibRS5
             {
                 foreach (RS5DirectoryEntry dirent in archive)
                 {
-                    if (!directory.ContainsKey(dirent.Name))
-                    {
-                        directory[dirent.Name] = dirent;
-                    }
+                    directory[dirent.Name] = dirent;
                 }
             }
 

--- a/RS5-Extractor/Program.cs
+++ b/RS5-Extractor/Program.cs
@@ -191,7 +191,7 @@ namespace RS5_Extractor
                 }
             }
 
-            foreach (string filename in rs5files.OrderBy(v => v))
+            foreach (string filename in rs5files.OrderByDescending(v => v))
             {
                 string filepath = Path.Combine(path, filename);
                 Console.WriteLine("Using {0} file from {1}", filename, filepath);
@@ -350,19 +350,12 @@ namespace RS5_Extractor
                 Dictionary<string, RS5DirectoryEntry> directory = OpenRS5Files();
                 Console.Write("Processing environment ... ");
                 SubStream environdata = directory["environment"].Data.Chunks["DATA"].Data;
-                using (Stream environfile = File.Create("environment.bin"))
-                {
-                    environdata.CopyTo(environfile);
-                }
-                RS5Environment environ = new RS5Environment(environdata);
-                Dictionary<string, List<AnimationClip>> animclips = ProcessEnvironmentAnimations(environ);
-                Console.WriteLine("Done");
-                XElement environ_xml = environ.ToXML();
-
                 try
                 {
-                    environ_xml.Save("environment.xml");
-                    WriteRS5Contents(directory, animclips);
+                    using (Stream environfile = File.Create("environment.bin"))
+                    {
+                        environdata.CopyTo(environfile);
+                    }
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -377,10 +370,18 @@ namespace RS5_Extractor
                     if (keyinfo.KeyChar == 'y' || keyinfo.KeyChar == 'Y')
                     {
                         Environment.CurrentDirectory = exepath;
-                        environ_xml.Save("environment.xml");
-                        WriteRS5Contents(directory, animclips);
+                        using (Stream environfile = File.Create("environment.bin"))
+                        {
+                            environdata.CopyTo(environfile);
+                        }
                     }
                 }
+                RS5Environment environ = new RS5Environment(environdata);
+                Dictionary<string, List<AnimationClip>> animclips = ProcessEnvironmentAnimations(environ);
+                Console.WriteLine("Done");
+                XElement environ_xml = environ.ToXML();
+                environ_xml.Save("environment.xml");
+                WriteRS5Contents(directory, animclips);
             }
             catch (FileNotFoundException)
             {


### PR DESCRIPTION
Partially through extracting files, the following error is thrown:

``Caught exception: Ionic.Zlib.ZlibException: Bad state (unknown compression method (0x00))``

This PR fixes this issue, and allows the full archive to be extracted.


Additionally, the existing handler for the case where the user lacks write access to the working directory is non-functional. If the extractor is run more than once (e.g. for testing purposes), an error is thrown:

``Caught exception: System.ArgumentException: Illegal characters in path.``

 This PR fixes that issue, as well.